### PR TITLE
feat: implementar interfaz para actualizar apostador

### DIFF
--- a/src/app/actualizar-apostador/actualizar-apostador.component.html
+++ b/src/app/actualizar-apostador/actualizar-apostador.component.html
@@ -1,1 +1,101 @@
-<p>actualizar-apostador works!</p>
+<div class="col-md-6 offset-md-3">
+    <h3 class="text-center">Edición de cuenta apostador</h3>
+    <form (ngSubmit)= "onSubmit()" #empleadoForm = "ngForm">
+
+        <div class="form-group">
+            <label>DNI : </label>
+            <input type = "text"  disabled
+            class="form-control"
+            id = "DNI"
+            [(ngModel)] = "apostador.dni"
+            name = "DNI"
+            required
+            minlength="8"
+            maxlength="8"
+            placeholder="Digite su dni "
+            #nombre = "ngModel"
+            >
+        </div>
+      
+        <div class="form-group">
+        <label>Nombre : </label>
+        <input type = "text"
+        class="form-control"
+        id = "nombre"
+        [(ngModel)] = "apostador.nombre"
+        name = "nombre"
+        required
+        minlength="3"
+        maxlength="30"
+        placeholder="Digite su nombre "
+        #nombre = "ngModel"
+        >
+      </div>
+
+      <div class="form-group">
+        <label>Telefono : </label>
+        <input type = "text"
+        class="form-control"
+        id = "telefono"
+        [(ngModel)] = "apostador.telefono"
+        name = "telefono"
+        required
+        minlength="9"
+        maxlength="9"
+        placeholder="Digite su telefono "
+        #nombre = "ngModel"
+        >
+      </div>
+      
+      <div class="form-group">
+        <label>Correo : </label>
+        <input type = "correo"
+        class="form-control"
+        id = "correo"
+        [(ngModel)] = "apostador.correo"
+        name = "correo"
+        pattern ="[a-zA-Z0-9_]+([.][a-zA-Z0-9_]+)*@[a-zA-Z0-9_]+([.][a-zA-Z0-9_]+)*[.][a-zA-Z]{1,5}"
+        required
+        placeholder="Digite su correo "
+        #email = "ngModel"
+        >
+        <div class="alert alert-danger" *ngIf= "email.invalid"><p>Debe tener el formato de un correo</p>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label>Direccion : </label>
+        <input type = "text"
+        class="form-control"
+        id = "direccion"
+        [(ngModel)] = "apostador.direccion"
+        name = "direccion"
+        required
+        minlength="3"
+        maxlength="30"
+        placeholder="Digite su direccion "
+        #nombre = "ngModel"
+        >
+      </div>
+
+      <div class="form-group">
+        <label>Contraseña : </label>
+        <input type = "password"
+        class="form-control"
+        id = "contrasena"
+        [(ngModel)] = "apostador.contrasena"
+        name = "contrasena"
+        required
+        minlength="5"
+        maxlength="15"
+        placeholder="Digite su contrasena "
+        #nombre = "ngModel"
+        >
+      </div>
+
+      
+      
+  
+      <button class="btn btn-success" [disabled]= "!empleadoForm.form.valid">Guardar</button>
+    </form>
+  </div>

--- a/src/app/actualizar-apostador/actualizar-apostador.component.ts
+++ b/src/app/actualizar-apostador/actualizar-apostador.component.ts
@@ -1,10 +1,36 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApostadorService } from '../apostador.service';
+import { Apostador } from '../apostador';
+
+import { ActivatedRoute, Router } from '@angular/router';
+
 
 @Component({
   selector: 'app-actualizar-apostador',
   templateUrl: './actualizar-apostador.component.html',
   styleUrls: ['./actualizar-apostador.component.css']
 })
-export class AbrirEditarApostadorComponent {
+export class AbrirEditarApostadorComponent implements OnInit{
+
+  dni:number;
+  apostador:Apostador = new Apostador();
+  constructor(private apostadorService:ApostadorService,private router:Router,private route:ActivatedRoute) { }
+
+  ngOnInit(): void {
+    this.dni = this.route.snapshot.params['dni'];
+    this.apostadorService.obtenerApostadorPorDNI(this.dni).subscribe(dato =>{
+      this.apostador = dato;
+    },error => console.log(error));
+  }
+
+  irAlaListaApostador(){
+    this.router.navigate(['/apostador']);
+  }
+
+  onSubmit(){
+    this.apostadorService.actualizarApostador(this.apostador).subscribe(dato => {
+      this.irAlaListaApostador();
+    },error => console.log(error));
+  }
 
 }


### PR DESCRIPTION
Buenas noches equipo, 
se implemento la interfaz para actualizar apostador permite cambiar todos los datos personales menos el DNI.
Lo puse a prueba y funcionó correctamente.
Por favor revisar. 